### PR TITLE
Update ImageTag to support Unity 6 versions

### DIFF
--- a/src/model/image-tag.ts
+++ b/src/model/image-tag.ts
@@ -27,7 +27,7 @@ class ImageTag {
   }
 
   static get versionPattern() {
-    return /^20\d{2}\.\d\.\w{3,4}|3$/;
+   return /^(20\d{2}\.\d\.\w{3,4}|6000\.\d\.\w{3,4})$/;
   }
 
   static get imageSuffixes() {


### PR DESCRIPTION
Unity went from 20xx.x.xxxx to 6000.x.xxxx, which broke activations. This should fix it.

#### Changes
- Updated the versionPattern

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Tests (I've tested it)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded the accepted image version formats to support a broader range of version identifiers, ensuring improved compatibility and flexibility when managing image tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->