### PR TITLE
Draft: Support Unity 6.x

### DIFF
--- a/src/model/image-tag.test.ts
+++ b/src/model/image-tag.test.ts
@@ -8,8 +8,12 @@ describe('ImageTag', () => {
       expect(() => new ImageTag(unityVersion)).not.toThrow();
     });
 
-    test.each(['2000.0.0f0', '2011.1.11f1'])('accepts %p version format', (version) => {
+    test.each(['2000.0.0f0', '2011.1.11f1', '6000.0.0f0'])('accepts %p version format', (version) => {
       expect(() => new ImageTag(version)).not.toThrow();
+    });
+
+    test.each(['1999.1.1f1', '6000.1.invalid'])('rejects %p version format', (version) => {
+      expect(() => new ImageTag(version)).toThrow(`Invalid version "${version}".`);
     });
   });
   describe('toString', () => {

--- a/src/model/image-tag.ts
+++ b/src/model/image-tag.ts
@@ -27,7 +27,7 @@ class ImageTag {
   }
 
   static get versionPattern() {
-    return /^20\d{2}\.\d\.\w{3,4}|3$/;
+    return /^(20\d{2}\.\d\.\w{3,4}|6000\.\d\.\w{3,4})$/;
   }
 
   static get imageSuffixes() {


### PR DESCRIPTION
#### Changes

Follow up on https://github.com/game-ci/unity-activate/pull/106 fix formatting + add unit test.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for Unity image versions in the 6000.x.x series.
  - Tightened version validation to require full-pattern matches, improving reliability.
  - More explicit error messages for invalid version formats.

- Tests
  - Added tests validating acceptance of “6000.0.0f0”.
  - Added tests ensuring invalid versions such as “1999.1.1f1” and “6000.1.invalid” are rejected with clear errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->